### PR TITLE
InterfaceKit support

### DIFF
--- a/phidgets_api/CMakeLists.txt
+++ b/phidgets_api/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(phidgets_api src/phidget.cpp
                          src/imu.cpp
+                         src/ik.cpp
                          src/ir.cpp)
 
 add_dependencies(phidgets_api ${catkin_EXPORTED_TARGETS})

--- a/phidgets_api/include/phidgets_api/ik.h
+++ b/phidgets_api/include/phidgets_api/ik.h
@@ -1,0 +1,33 @@
+#ifndef PHIDGETS_API_IK_H
+#define PHIDGETS_API_IK_H
+
+#include "phidgets_api/phidget.h"
+
+namespace phidgets {
+
+class IK: public Phidget
+{
+  public:
+
+    IK();
+
+  protected:
+ 
+    CPhidgetInterfaceKitHandle ik_handle_;
+    
+    virtual void sensorHandler(
+      int index, 
+      int sensorValue);
+
+  private:
+
+    static int SensorHandler(
+      CPhidgetInterfaceKitHandle ik, 
+      void * userptr,
+      int index, 
+      int sensorValue);
+};
+
+} //namespace phidgets
+
+#endif // PHIDGETS_API_IK_H

--- a/phidgets_api/include/phidgets_api/ik.h
+++ b/phidgets_api/include/phidgets_api/ik.h
@@ -14,10 +14,12 @@ class IK: public Phidget
   protected:
  
     CPhidgetInterfaceKitHandle ik_handle_;
-    
     virtual void sensorHandler(
       int index, 
       int sensorValue);
+    virtual void inputHandler(
+      int index, 
+      int inputValue);
 
   private:
 
@@ -26,6 +28,11 @@ class IK: public Phidget
       void * userptr,
       int index, 
       int sensorValue);
+    static int InputHandler(
+      CPhidgetInterfaceKitHandle ik, 
+      void * userptr,
+      int index, 
+      int inputValue);
 };
 
 } //namespace phidgets

--- a/phidgets_api/src/ik.cpp
+++ b/phidgets_api/src/ik.cpp
@@ -14,10 +14,9 @@ IK::IK():
 
   // register base class callbacks
   Phidget::registerHandlers();
-  
+
   // register ik data callback
   CPhidgetInterfaceKit_set_OnSensorChange_Handler(ik_handle_, SensorHandler, this);
-
 }
 
 
@@ -30,6 +29,17 @@ int IK::SensorHandler(CPhidgetInterfaceKitHandle ik, void *userptr, int index, i
 void IK::sensorHandler(int index, int sensorValue)
 {
   printf("index: %d, value: %d\n", index, sensorValue);
+}
+
+int IK::InputHandler(CPhidgetInterfaceKitHandle ik, void *userptr, int index, int inputValue)
+{
+  ((IK*)userptr)->inputHandler(index, inputValue);
+  return 0;
+}
+
+void IK::inputHandler(int index, int inputValue)
+{
+  printf("index: %d, value: %d\n", index, inputValue);
 }
 
 } // namespace phidgets

--- a/phidgets_api/src/ik.cpp
+++ b/phidgets_api/src/ik.cpp
@@ -1,0 +1,35 @@
+#include "phidgets_api/ik.h"
+
+namespace phidgets {
+
+IK::IK():
+  Phidget(),
+  ik_handle_(0)
+{
+  // create the handle
+  CPhidgetInterfaceKit_create(&ik_handle_);
+
+  // pass handle to base class
+  Phidget::init((CPhidgetHandle)ik_handle_);
+
+  // register base class callbacks
+  Phidget::registerHandlers();
+  
+  // register ik data callback
+  CPhidgetInterfaceKit_set_OnSensorChange_Handler(ik_handle_, SensorHandler, this);
+
+}
+
+
+int IK::SensorHandler(CPhidgetInterfaceKitHandle ik, void *userptr, int index, int sensorValue)
+{
+  ((IK*)userptr)->sensorHandler(index, sensorValue);
+  return 0;
+}
+
+void IK::sensorHandler(int index, int sensorValue)
+{
+  printf("index: %d, value: %d\n", index, sensorValue);
+}
+
+} // namespace phidgets

--- a/phidgets_ik/CMakeLists.txt
+++ b/phidgets_ik/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(phidgets_ik)
+
+find_package(catkin REQUIRED COMPONENTS geometry_msgs nodelet phidgets_api roscpp sensor_msgs std_msgs std_srvs tf)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES phidgets_ik
+  CATKIN_DEPENDS geometry_msgs nodelet phidgets_api roscpp sensor_msgs std_msgs std_srvs tf
+)
+
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+add_library(phidgets_ik src/ik_ros_i.cpp)
+
+add_executable(phidgets_ik_node src/phidgets_ik_node.cpp)
+
+add_dependencies(phidgets_ik ${catkin_EXPORTED_TARGETS})
+add_dependencies(phidgets_ik_node ${catkin_EXPORTED_TARGETS})
+
+target_link_libraries(phidgets_ik ${catkin_LIBRARIES})
+target_link_libraries(phidgets_ik_node ${catkin_LIBRARIES} phidgets_ik)
+
+install(TARGETS phidgets_ik phidgets_ik_node
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+   FILES_MATCHING PATTERN "*.h"
+)

--- a/phidgets_ik/include/phidgets_ik/ik_ros_i.h
+++ b/phidgets_ik/include/phidgets_ik/ik_ros_i.h
@@ -6,6 +6,8 @@
 #include <std_msgs/Float32.h>
 #include <phidgets_api/ik.h>
 
+#include <vector>
+
 namespace phidgets {
 
 class IKRosI : public IK 
@@ -20,8 +22,8 @@ class IKRosI : public IK
     int n_in;
     int n_out;
     int n_sensors;
-    ros::Publisher in_pubs_[16];
-    ros::Publisher sensor_pubs_[16];
+    std::vector<ros::Publisher> in_pubs_;
+    std::vector<ros::Publisher> sensor_pubs_;
 
   private:
 

--- a/phidgets_ik/include/phidgets_ik/ik_ros_i.h
+++ b/phidgets_ik/include/phidgets_ik/ik_ros_i.h
@@ -1,0 +1,27 @@
+#ifndef PHIDGETS_IK_IK_ROS_I_H
+#define PHIDGETS_IK_IK_ROS_I_H
+
+#include <ros/ros.h>
+#include <phidgets_api/ik.h>
+
+namespace phidgets {
+
+class IKRosI : public IK 
+{
+
+  public:
+
+    IKRosI(ros::NodeHandle nh, ros::NodeHandle nh_private);
+
+  private:
+
+    ros::NodeHandle nh_;
+    ros::NodeHandle nh_private_;
+
+    void initDevice();
+    void sensorHandler(int index, int sensorValue);
+};
+
+} //namespace phidgets
+
+#endif // PHIDGETS_IK_IK_ROS_I_H

--- a/phidgets_ik/include/phidgets_ik/ik_ros_i.h
+++ b/phidgets_ik/include/phidgets_ik/ik_ros_i.h
@@ -10,6 +10,16 @@
 
 namespace phidgets {
 
+class output_setter {
+  public:
+    output_setter(CPhidgetInterfaceKitHandle ik_handle, int index);
+    virtual void set_msg_callback(const std_msgs::Bool::ConstPtr& msg);
+    ros::Subscriber subscription;
+  protected:
+    int index;
+    CPhidgetInterfaceKitHandle ik_handle_;
+};
+
 class IKRosI : public IK 
 {
 
@@ -24,6 +34,7 @@ class IKRosI : public IK
     int n_sensors;
     std::vector<ros::Publisher> in_pubs_;
     std::vector<ros::Publisher> sensor_pubs_;
+    std::vector<output_setter*> out_subs_;
 
   private:
 

--- a/phidgets_ik/include/phidgets_ik/ik_ros_i.h
+++ b/phidgets_ik/include/phidgets_ik/ik_ros_i.h
@@ -2,6 +2,8 @@
 #define PHIDGETS_IK_IK_ROS_I_H
 
 #include <ros/ros.h>
+#include <std_msgs/Bool.h>
+#include <std_msgs/Float32.h>
 #include <phidgets_api/ik.h>
 
 namespace phidgets {
@@ -13,6 +15,14 @@ class IKRosI : public IK
 
     IKRosI(ros::NodeHandle nh, ros::NodeHandle nh_private);
 
+  protected:
+
+    int n_in;
+    int n_out;
+    int n_sensors;
+    ros::Publisher in_pubs_[16];
+    ros::Publisher sensor_pubs_[16];
+
   private:
 
     ros::NodeHandle nh_;
@@ -20,6 +30,7 @@ class IKRosI : public IK
 
     void initDevice();
     void sensorHandler(int index, int sensorValue);
+    void inputHandler(int index, int inputValue);
 };
 
 } //namespace phidgets

--- a/phidgets_ik/package.xml
+++ b/phidgets_ik/package.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<package>
+  <name>phidgets_ik</name>
+  <version>0.0.1</version>
+  <description>Driver for the Phidgets InterfaceKit devices</description>
+
+  <maintainer email="jsarrett@gmail.com">James Sarrett</maintainer>
+
+  <license>BSD</license>
+
+  <!--
+  <url type="website">http://ros.org/wiki/phidgets_ir</url>
+  -->
+
+  <author>James Sarrett</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>nodelet</build_depend>
+  <build_depend>phidgets_api</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+  <build_depend>tf</build_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>nodelet</run_depend>
+  <run_depend>phidgets_api</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
+  <run_depend>tf</run_depend>
+</package>

--- a/phidgets_ik/src/ik_ros_i.cpp
+++ b/phidgets_ik/src/ik_ros_i.cpp
@@ -1,10 +1,14 @@
 #include "phidgets_ik/ik_ros_i.h"
+#include <stdio.h>
 
 namespace phidgets {
 
 IKRosI::IKRosI(ros::NodeHandle nh, ros::NodeHandle nh_private):
   IK(),
-  nh_(nh), 
+  n_in(0),
+  n_out(0),
+  n_sensors(0),
+  nh_(nh),
   nh_private_(nh_private)
 {
   ROS_INFO ("Starting Phidgets IK");
@@ -25,13 +29,46 @@ void IKRosI::initDevice()
     CPhidget_getErrorDescription(result, &err);
     ROS_FATAL("Problem waiting for IK attachment: %s", err);
   }
+
+  CPhidgetInterfaceKit_getInputCount(ik_handle_, &n_in);
+  CPhidgetInterfaceKit_getOutputCount(ik_handle_, &n_out);
+  CPhidgetInterfaceKit_getSensorCount(ik_handle_, &n_sensors);
+  ROS_INFO("%d inputs, %d outputs, %d sensors", n_in, n_out, n_sensors);
+  for (int i = 0; i < n_in; i++) {
+    char topicname[] = "input00";
+    snprintf(topicname, sizeof(topicname), "input%02d", i);
+    in_pubs_[i] = nh_.advertise<std_msgs::Bool>(
+        topicname, 1);
+  }
+  for (int i = 0; i < n_sensors; i++) {
+    char topicname[] = "sensor00";
+    snprintf(topicname, sizeof(topicname), "sensor%02d", i);
+    sensor_pubs_[i] = nh_.advertise<std_msgs::Float32>(
+        topicname, 1);
+  }
 }
 
 void IKRosI::sensorHandler(int index, int sensorValue)
 {
   // do nothing - just refer to base class callbalck, which prints the values
   IK::sensorHandler(index, sensorValue);
+  //get rawsensorvalue and divide by 4096, which according to the documentation for both the IK888 and IK222 are the maximum senosr value
+  int rawval = 0;
+  CPhidgetInterfaceKit_getSensorRawValue(ik_handle_, index, &rawval);
+  std_msgs::Float32 msg;
+  msg.data = float(rawval)/4095.0f;
+  sensor_pubs_[index].publish(msg);
 }
+
+void IKRosI::inputHandler(int index, int inputValue)
+{
+  // do nothing - just refer to base class callbalck, which prints the values
+  IK::inputHandler(index, inputValue);
+  std_msgs::Bool msg;
+  msg.data = inputValue != 0;
+  in_pubs_[index].publish(msg);
+}
+
 
 } // namespace phidgets
 

--- a/phidgets_ik/src/ik_ros_i.cpp
+++ b/phidgets_ik/src/ik_ros_i.cpp
@@ -39,6 +39,13 @@ void IKRosI::initDevice()
     snprintf(topicname, sizeof(topicname), "input%02d", i);
     in_pubs_.push_back(nh_.advertise<std_msgs::Bool>(topicname, 1));
   }
+  for (int i = 0; i < n_out; i++) {
+    char topicname[] = "output00";
+    snprintf(topicname, sizeof(topicname), "output%02d", i);
+    output_setter * s = new output_setter(ik_handle_, i);
+    s->subscription = nh_.subscribe(topicname, 1, &output_setter::set_msg_callback, s);
+    out_subs_.push_back(s);
+  }
   for (int i = 0; i < n_sensors; i++) {
     char topicname[] = "sensor00";
     snprintf(topicname, sizeof(topicname), "sensor%02d", i);
@@ -71,6 +78,17 @@ void IKRosI::inputHandler(int index, int inputValue)
   }
 }
 
+void output_setter::set_msg_callback(const std_msgs::Bool::ConstPtr& msg)
+{
+  ROS_INFO("Setting output %d to %d", index, msg->data);
+  CPhidgetInterfaceKit_setOutputState(ik_handle_, index, msg->data);
+}
+
+output_setter::output_setter(CPhidgetInterfaceKitHandle ik_handle, int index)
+{
+    this->ik_handle_ = ik_handle_;
+    this->index = index;
+}
 
 } // namespace phidgets
 

--- a/phidgets_ik/src/ik_ros_i.cpp
+++ b/phidgets_ik/src/ik_ros_i.cpp
@@ -57,7 +57,9 @@ void IKRosI::sensorHandler(int index, int sensorValue)
   CPhidgetInterfaceKit_getSensorRawValue(ik_handle_, index, &rawval);
   std_msgs::Float32 msg;
   msg.data = float(rawval)/4095.0f;
-  sensor_pubs_[index].publish(msg);
+  if (sensor_pubs_[index]) {
+    sensor_pubs_[index].publish(msg);
+  }
 }
 
 void IKRosI::inputHandler(int index, int inputValue)
@@ -66,7 +68,9 @@ void IKRosI::inputHandler(int index, int inputValue)
   IK::inputHandler(index, inputValue);
   std_msgs::Bool msg;
   msg.data = inputValue != 0;
-  in_pubs_[index].publish(msg);
+  if (in_pubs_[index]) {
+    in_pubs_[index].publish(msg);
+  }
 }
 
 

--- a/phidgets_ik/src/ik_ros_i.cpp
+++ b/phidgets_ik/src/ik_ros_i.cpp
@@ -1,0 +1,37 @@
+#include "phidgets_ik/ik_ros_i.h"
+
+namespace phidgets {
+
+IKRosI::IKRosI(ros::NodeHandle nh, ros::NodeHandle nh_private):
+  IK(),
+  nh_(nh), 
+  nh_private_(nh_private)
+{
+  ROS_INFO ("Starting Phidgets IK");
+
+  initDevice();
+}
+
+void IKRosI::initDevice()
+{
+  ROS_INFO("Opening device");
+  open(-1);
+
+  ROS_INFO("Waiting for IK to be attached...");
+  int result = waitForAttachment(10000);
+  if(result)
+  {
+    const char *err;
+    CPhidget_getErrorDescription(result, &err);
+    ROS_FATAL("Problem waiting for IK attachment: %s", err);
+  }
+}
+
+void IKRosI::sensorHandler(int index, int sensorValue)
+{
+  // do nothing - just refer to base class callbalck, which prints the values
+  IK::sensorHandler(index, sensorValue);
+}
+
+} // namespace phidgets
+

--- a/phidgets_ik/src/ik_ros_i.cpp
+++ b/phidgets_ik/src/ik_ros_i.cpp
@@ -19,7 +19,10 @@ IKRosI::IKRosI(ros::NodeHandle nh, ros::NodeHandle nh_private):
 void IKRosI::initDevice()
 {
   ROS_INFO("Opening device");
-  open(-1);
+  int serial_num;
+  if (!nh_private_.getParam("serial", serial_num))
+    serial_num = -1; //defalut open any device
+  open(serial_num);
 
   ROS_INFO("Waiting for IK to be attached...");
   int result = waitForAttachment(10000);

--- a/phidgets_ik/src/ik_ros_i.cpp
+++ b/phidgets_ik/src/ik_ros_i.cpp
@@ -37,14 +37,12 @@ void IKRosI::initDevice()
   for (int i = 0; i < n_in; i++) {
     char topicname[] = "input00";
     snprintf(topicname, sizeof(topicname), "input%02d", i);
-    in_pubs_[i] = nh_.advertise<std_msgs::Bool>(
-        topicname, 1);
+    in_pubs_.push_back(nh_.advertise<std_msgs::Bool>(topicname, 1));
   }
   for (int i = 0; i < n_sensors; i++) {
     char topicname[] = "sensor00";
     snprintf(topicname, sizeof(topicname), "sensor%02d", i);
-    sensor_pubs_[i] = nh_.advertise<std_msgs::Float32>(
-        topicname, 1);
+    sensor_pubs_.push_back(nh_.advertise<std_msgs::Float32>(topicname, 1));
   }
 }
 
@@ -57,7 +55,7 @@ void IKRosI::sensorHandler(int index, int sensorValue)
   CPhidgetInterfaceKit_getSensorRawValue(ik_handle_, index, &rawval);
   std_msgs::Float32 msg;
   msg.data = float(rawval)/4095.0f;
-  if (sensor_pubs_[index]) {
+  if ((sensor_pubs_.size() > index) && (sensor_pubs_[index])) {
     sensor_pubs_[index].publish(msg);
   }
 }
@@ -68,7 +66,7 @@ void IKRosI::inputHandler(int index, int inputValue)
   IK::inputHandler(index, inputValue);
   std_msgs::Bool msg;
   msg.data = inputValue != 0;
-  if (in_pubs_[index]) {
+  if ((in_pubs_.size() > index) && (in_pubs_[index])) {
     in_pubs_[index].publish(msg);
   }
 }

--- a/phidgets_ik/src/ik_ros_i.cpp
+++ b/phidgets_ik/src/ik_ros_i.cpp
@@ -31,6 +31,7 @@ void IKRosI::initDevice()
     const char *err;
     CPhidget_getErrorDescription(result, &err);
     ROS_FATAL("Problem waiting for IK attachment: %s", err);
+    exit(result);
   }
 
   CPhidgetInterfaceKit_getInputCount(ik_handle_, &n_in);

--- a/phidgets_ik/src/phidgets_ik_node.cpp
+++ b/phidgets_ik/src/phidgets_ik_node.cpp
@@ -1,0 +1,11 @@
+#include "phidgets_ik/ik_ros_i.h"
+
+int main(int argc, char **argv)
+{
+  ros::init (argc, argv, "PhidgetsIK");
+  ros::NodeHandle nh;
+  ros::NodeHandle nh_private("~");
+  phidgets::IKRosI ik(nh, nh_private);
+  ros::spin();
+  return 0;
+}

--- a/phidgets_imu/src/imu_ros_i.cpp
+++ b/phidgets_imu/src/imu_ros_i.cpp
@@ -136,6 +136,7 @@ void ImuRosI::initDevice()
 		const char *err;
 		CPhidget_getErrorDescription(result, &err);
 		ROS_FATAL("Problem waiting for IMU attachment: %s Make sure the USB cable is connected and you have executed the phidgets_api/share/setup-udev.sh script.", err);
+        exit(result);
 	}
 
   // calibrate on startup

--- a/phidgets_ir/src/ir_ros_i.cpp
+++ b/phidgets_ir/src/ir_ros_i.cpp
@@ -24,6 +24,7 @@ void IRRosI::initDevice()
 	  const char *err;
 		CPhidget_getErrorDescription(result, &err);
 		ROS_FATAL("Problem waiting for IR attachment: %s", err);
+        exit(result);
 	}
 }
 


### PR DESCRIPTION
This branch adds support for InterfaceKit Phidgets in a very similar style to the phidgets_ir node.  It shoudl allow multiple IKs to be attached and selected by serial number, but I have only tested it with 1 (fails to open when different serial is set, succeeds when correct on is set).  For each input reported by the phidget a topic is created named 'inputNN' where NN is the index, similarly it subscribes to topics 'outputNN' to allow outputs to be set.  It also publishes 'sensorNN' topics for each sensor which report Float32 values scaled to [0.0, 1.0].